### PR TITLE
Small cleanup for enable hint logic

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -23,7 +23,7 @@
         },
         "enableHint": {
           ".write": "auth != null && auth.uid == data.parent().child('host').val() && newData.exists()",
-          ".validate": "newData.isBoolean()"
+          ".validate": "newData.isBoolean() && data.parent().child('access').val() == 'private'"
         }
       }
     },

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -104,11 +104,7 @@ export const finishGame = functions.https.onCall(async (data, context) => {
   }
 
   // Check if hints are enabled; and if so, ignore the game in statistics
-  if (
-    snapshot.child("enableHint").val() &&
-    snapshot.child("users").numChildren() === 1 &&
-    snapshot.child("access").val() === "private"
-  ) {
+  if (snapshot.child("enableHint").val()) {
     return;
   }
 

--- a/scripts/src/calcStats.js
+++ b/scripts/src/calcStats.js
@@ -63,12 +63,7 @@ export async function calcStats() {
             const { finalTime, scores } = replayEvents(gameData, gameMode);
 
             // Check if hints are enabled; and if so, ignore the game in statistics
-            if (
-              game.child("enableHint").val() &&
-              game.child("users").numChildren() === 1 &&
-              game.child("access").val() === "private" &&
-              gameMode === "normal"
-            ) {
+            if (game.child("enableHint").val()) {
               return;
             }
 

--- a/src/components/GameSettings.js
+++ b/src/components/GameSettings.js
@@ -54,8 +54,8 @@ function GameSettings({ game, gameId, userId }) {
             control={<Switch checked={hasHint(game)} onChange={toggleHint} />}
             label="Enable Hints"
             disabled={
-              Object.keys(game.users || {}).length > 1 ||
-              game.access !== "private"
+              game.access !== "private" ||
+              Object.keys(game.users || {}).length !== 1
             }
           />
         </Tooltip>

--- a/src/util.js
+++ b/src/util.js
@@ -351,9 +351,8 @@ export function formatTime(t, hideSubsecond) {
 export function hasHint(game) {
   return (
     game.enableHint &&
-    game.users &&
-    Object.keys(game.users).length === 1 &&
-    game.access === "private"
+    game.access === "private" &&
+    Object.keys(game.users || {}).length === 1
   );
 }
 


### PR DESCRIPTION
Enforce that hints are only used in private games in db rules.

Skip all games with enableHint == true in stats on the server side. It's not worth duplicating logic if someone manages to set enableHint for a multiplayer game.